### PR TITLE
Remove copied code

### DIFF
--- a/src/clj/iota.clj
+++ b/src/clj/iota.clj
@@ -34,56 +34,6 @@
 ;; ;;; ;; ;;; ;; ;;; ;; ;;; ;; ;;; ;; ;;; ;; ;;; ;; ;;; ;; ;;;
 
 
-;; COPY of clojure.core/reducer's fork/join pools implementation
-;; and foldvec implementation 
-;; included here because foldvec needs to call these but they're private...
-(defmacro ^:private compile-if
-  "Evaluate `exp` and if it returns logical true and doesn't error, expand to
-  `then`.  Else expand to `else`.
-
-  (compile-if (Class/forName \"java.util.concurrent.ForkJoinTask\")
-    (do-cool-stuff-with-fork-join)
-    (fall-back-to-executor-services))"
-  [exp then else]
-  (if (try (eval exp)
-           (catch Throwable _ false))
-    `(do ~then)
-        `(do ~else)))
-
-(compile-if
- (Class/forName "java.util.concurrent.ForkJoinTask")
- ;; We're running a JDK 7+
- (do
-   (def pool (delay (java.util.concurrent.ForkJoinPool.)))
-
-   (defn fjtask [^Callable f]
-     (java.util.concurrent.ForkJoinTask/adapt f))
-
-   (defn fjinvoke [f]
-     (if (java.util.concurrent.ForkJoinTask/inForkJoinPool)
-       (f)
-       (.invoke ^java.util.concurrent.ForkJoinPool @pool ^java.util.concurrent.ForkJoinTask (fjtask f))))
-
-   (defn fjfork [task] (.fork ^java.util.concurrent.ForkJoinTask task))
-
-   (defn fjjoin [task] (.join ^java.util.concurrent.ForkJoinTask task)))
- ;; We're running a JDK <7
- (do
-   (def pool (delay (jsr166y.ForkJoinPool.)))
-
-   (defn fjtask [^Callable f]
-     (jsr166y.ForkJoinTask/adapt f))
-   
- (defn fjinvoke [f]
-   (if (jsr166y.ForkJoinTask/inForkJoinPool)
-     (f)
-     (.invoke ^jsr166y.ForkJoinPool @pool ^jsr166y.ForkJoinTask (fjtask f))))
-
- (defn fjfork [task] (.fork ^jsr166y.ForkJoinTask task))
- 
- (defn fjjoin [task] (.join ^jsr166y.ForkJoinTask task))))
-
-
 ;; Implement CollFold for FileVector
 ;; Note: copied+modified from clojure.core.reducers/foldvec
 (defn- foldvec
@@ -97,11 +47,11 @@
          v1 (.subvec v 0 split)
          v2 (.subvec v split (count v))
          fc (fn [child] #(foldvec child n combinef reducef))]
-     (fjinvoke
+     (#'r/fjinvoke
       #(let [f1 (fc v1)
              t2 (r/fjtask (fc v2))]
-         (fjfork t2)
-         (combinef (f1) (fjjoin t2)))))))
+         (#'r/fjfork t2)
+         (combinef (f1) (#'r/fjjoin t2)))))))
 
 (extend-protocol r/CollFold
   iota.FileVector


### PR DESCRIPTION
...and call the private functions directly by accessing their vars. This still has the problem of relying on private code, but at least there is on need to keep both copies in sync.
